### PR TITLE
Content-Length now calculates correctly when JSON contains special characters

### DIFF
--- a/proxyServer/timelineTestProxyServer.js
+++ b/proxyServer/timelineTestProxyServer.js
@@ -7,14 +7,14 @@ const app = express();
 version = 1.8;
 
 //Port to listen on
-const port = 8081;
+const port = 8080;
 
 //More logging
-debug = false
+debug = true
 
 //Don't actually send the pin to rws
 //Logs result as 200
-debug_disable_rws_callout = false
+debug_disable_rws_callout = true
 
 //If you're not running this behind a reverse proxy, you should use https
 use_https = false

--- a/proxyServer/timelineTestProxyServer.js
+++ b/proxyServer/timelineTestProxyServer.js
@@ -7,14 +7,14 @@ const app = express();
 version = 1.8;
 
 //Port to listen on
-const port = 8080;
+const port = 8081;
 
 //More logging
-debug = true
+debug = false
 
 //Don't actually send the pin to rws
 //Logs result as 200
-debug_disable_rws_callout = true
+debug_disable_rws_callout = false
 
 //If you're not running this behind a reverse proxy, you should use https
 use_https = false
@@ -468,7 +468,7 @@ function submitPinToRWS(pinData, callBack, errorCallBack, callBackObject ) {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
-      'Content-Length': data.length,
+      'Content-Length': Buffer.byteLength(data),
       'X-User-Token': pinData.token
     }
   }


### PR DESCRIPTION
Hi Will,

I have had this newline issue resurface so have taken the time to investigate further and have resolved the issue.

The issue was that `String.length` was being used to calculate a Content-Length header, causing a rejection on the pebble API due to a length mismatch. This is because `String.length` does not take into account special characters or multi-byte unicode characters. Replacing this length calculation with `Buffer.byteLength()`  fixes the issue.

JSON used in test:
```json
{
  "time": "A",
  "meta": {
    "clocktime": {
      "hour": 23,
      "minute": 59
    },
    "notifyOnArrival": false
  },
  "layout": {
    "type": "genericPin",
    "title": "Todays word:",
    "body": "(US, humorous) Used to report that a (major) problem has occurred.\n NASA’s Apollo 13 mission to the Moon launched on this day in 1970, but was aborted after an oxygen tank triggered an explosion. The spacecraft returned safely\n to\r Earth\n\n\n on April 17.",
    "subtitle": "Houston, we have a problem\n",
    "tinyIcon": "system://images/NEWS_EVENT"
  },
  "token": "RETRACTED"
}
```

Content-Length calculated from data.length:
```:58:17 GMT+0100 (British Summer Time)] Not using HTTPS! Ensure you're running behind a reverse proxy
[Sun Apr 11 2021 13:58:17 GMT+0100 (British Summer Time)] Listening on port 8081
[Sun Apr 11 2021 13:58:21 GMT+0100 (British Summer Time)] ws-ifttt-2e20b648-23f4::ifttt::createPin
[Sun Apr 11 2021 13:58:21 GMT+0100 (British Summer Time)] ws-ifttt-2e20b648-23f4::ifttt::validatePin
[Sun Apr 11 2021 13:58:21 GMT+0100 (British Summer Time)] ws-ifttt-2e20b648-23f4::ifttt::validatePin::pinValid
[Sun Apr 11 2021 13:58:21 GMT+0100 (British Summer Time)] ws-ifttt-2e20b648-23f4::submitPin
[Sun Apr 11 2021 13:58:21 GMT+0100 (British Summer Time)] ws-ifttt-2e20b648-23f4::submitPin::rwscode:400
[Sun Apr 11 2021 13:58:21 GMT+0100 (British Summer Time)] ws-ifttt-2e20b648-23f4::submitPin::errorcode:400
[Sun Apr 11 2021 13:58:21 GMT+0100 (British Summer Time)] RWS Error msg: <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>400 Bad Request</title>
<h1>Bad Request</h1>
<p>The browser (or proxy) sent a request that this server could not understand.</p>
```

Content-Length calculated from Buffer.byteLength:
```
[Sun Apr 11 2021 13:56:53 GMT+0100 (British Summer Time)] Not using HTTPS! Ensure you're running behind a reverse proxy
[Sun Apr 11 2021 13:56:53 GMT+0100 (British Summer Time)] Listening on port 8081
[Sun Apr 11 2021 13:57:05 GMT+0100 (British Summer Time)] ws-ifttt-56a5c826-f55e::ifttt::createPin
[Sun Apr 11 2021 13:57:05 GMT+0100 (British Summer Time)] ws-ifttt-56a5c826-f55e::ifttt::validatePin
[Sun Apr 11 2021 13:57:05 GMT+0100 (British Summer Time)] ws-ifttt-56a5c826-f55e::ifttt::validatePin::pinValid
[Sun Apr 11 2021 13:57:05 GMT+0100 (British Summer Time)] ws-ifttt-56a5c826-f55e::submitPin
[Sun Apr 11 2021 13:57:05 GMT+0100 (British Summer Time)] ws-ifttt-56a5c826-f55e::submitPin::rwscode:200
[Sun Apr 11 2021 13:57:05 GMT+0100 (British Summer Time)] ws-ifttt-56a5c826-f55e::submitPin::success
[Sun Apr 11 2021 13:57:05 GMT+0100 (British Summer Time)] ws-ifttt-56a5c826-f55e::submitPin::data:OK
```

I additionally tested the same with a JSON object that contains no special character and had no issues too.